### PR TITLE
Make it dependent on 2.3+ so people who use SF 2.4+ can install too.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.4",
-        "sensio/framework-extra-bundle": "2.3.*",
+        "sensio/framework-extra-bundle": "~2.3",
         "prismic/php-sdk": "dev-master"
     },
 


### PR DESCRIPTION
Make it dependent on 2.3+ so people who use SF 2.4+ can install too (they use 3.0).
