### PR TITLE
Replaced RouterInterface with UrlGeneratorInterface

### DIFF
--- a/Helper/LocalLinkResolver.php
+++ b/Helper/LocalLinkResolver.php
@@ -2,7 +2,7 @@
 
 namespace Prismic\Bundle\PrismicBundle\Helper;
 
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 use Prismic\Api;
 use Prismic\Ref;
@@ -12,18 +12,18 @@ use Prismic\Fragment\Link\DocumentLink;
 class LocalLinkResolver extends LinkResolver
 {
 
-    private $router; 
+    private $urlGenerator;
     private $api;
     private $maybeRef;
 
     /**
-     * @param RouterInterface $router
+     * @param UrlGeneratorInterface $urlGenerator
      * @param Api $api
      * @param string|null $maybeRef
      */
-    public function __construct(RouterInterface $router, Api $api, $maybeRef = null)
+    public function __construct(UrlGeneratorInterface $urlGenerator, Api $api, $maybeRef = null)
     {
-        $this->router = $router;
+        $this->urlGenerator = $urlGenerator;
         $this->api = $api;
         $this->maybeRef = $maybeRef;
     }
@@ -32,9 +32,9 @@ class LocalLinkResolver extends LinkResolver
      * @param DocumentLink $link
      * @return string
      */
-    public function resolve($link) 
+    public function resolve($link)
     {
-        return $this->router->generate('detail', array('id' => $link->getId(), 'slug' => $link->getSlug(), 'ref' => (string) $this->maybeRef));
+        return $this->urlGenerator->generate('detail', array('id' => $link->getId(), 'slug' => $link->getSlug(), 'ref' => (string) $this->maybeRef));
     }
 
 }

--- a/Helper/PrismicContext.php
+++ b/Helper/PrismicContext.php
@@ -2,7 +2,7 @@
 
 namespace Prismic\Bundle\PrismicBundle\Helper;
 
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 use Prismic\api;
 use Prismic\Ref;
@@ -12,7 +12,7 @@ use Prismic\Fragment\Link\DocumentLink;
 class PrismicContext
 {
     private $prismic;
-    private $router;
+    private $urlGenerator;
 
     private $accessToken;
     private $api;
@@ -25,10 +25,10 @@ class PrismicContext
      * @param PrismicHelper $prismic
      * @param RouterInterface $router
      */
-    public function __construct(PrismicHelper $prismic, RouterInterface $router)
+    public function __construct(PrismicHelper $prismic, UrlGeneratorInterface $urlGenerator)
     {
         $this->prismic = $prismic;
-        $this->router = $router;
+        $this->urlGenerator = $urlGenerator;
     }
 
     /**
@@ -108,12 +108,20 @@ class PrismicContext
     }
 
     /**
+     * @return UrlGeneratorInterface
+     */
+    public function getUrlGenerator()
+    {
+        return $this->urlGenerator;
+    }
+
+    /**
      * @return LocalLinkResolver
      */
     public function getLinkResolver()
     {
         if (!$this->linkResolver) {
-            $this->linkResolver = new LocalLinkResolver($this->router, $this->getApi(), $this->getMaybeRef());
+            $this->linkResolver = new LocalLinkResolver($this->urlGenerator, $this->getApi(), $this->getMaybeRef());
         }
 
         return $this->linkResolver;
@@ -136,7 +144,7 @@ class PrismicContext
      *
      * @return Document|null
      */
-    public function getDocument($id) 
+    public function getDocument($id)
     {
         $docs = $this->getApi()->forms()->everything->ref($this->getRef())->query(
                 '[[:d = at(document.id, "'.$id.'")]]'

--- a/Helper/PrismicHelper.php
+++ b/Helper/PrismicHelper.php
@@ -21,10 +21,10 @@ class PrismicHelper
     }
 
     /**
-     * @param string $customAccessToken 
+     * @param string $customAccessToken
      * @return Api
      */
-    public function getApiHome($customAccessToken = null) 
+    public function getApiHome($customAccessToken = null)
     {
         return Api::get($this->apiEndpoint, $customAccessToken ? $customAccessToken : $this->accessToken);
     }


### PR DESCRIPTION
Hi there,

I am currently building a Silex PrismicServiceProvider (expect more about this soon :smile:). And to reuse the context and helper classes of this bundle, I need to pass an UrlGeneratorInterface (app['url_generator']) instead of a RouterInterface instance. 
