### PR TITLE
Freezing the prismic.io PHP kit to a given version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.4",
-        "prismic/php-sdk": "dev-master"
+        "prismic/php-sdk": "1.0.4-dev"
     },
 
     "extra": {


### PR DESCRIPTION
I'm not a Symfonist, so bear with me.

A user on support has reported that a `composer update` broke his Symfony application. Indeed, we introduced some breaking changes in the PHP kit recently, which is likely to happen once in a while, and some of them may require changes in the Symfony Bundle. It seems that the version of the PHP kit is not frozen in the Symfony Bundle, and the master branch is pulled now, so it really should be frozen.

The 1.0.4-dev version of the kit is at the same time recent and stable; I believe it works with the Symfony Bundle, but I wouldn't really know how to check. Can someone freeze the version of the PHP kit to that version (hopefully, that's what I'm doing in that PR), and check that everything is alright, before someone else runs a deadly `composer update`?

Thanks a lot!
