### PR TITLE
Fix for returning first doc

### DIFF
--- a/Helper/PrismicContext.php
+++ b/Helper/PrismicContext.php
@@ -144,8 +144,8 @@ class PrismicContext
             ->submit()
         ;
 
-        if (is_array($docs) && count($docs) > 0) {
-            return $docs[0];
+        if (is_array($docs->getResults()) && count($docs->getResults()) > 0) {
+            return $docs->getResults()[0];
         }
 
         return null;


### PR DESCRIPTION
With the current php-sdk, the returning docs are in the results property. I do not know if it is used elsewhere in the code, but I fixed it in the getDocument() method for now.
