### PR TITLE
Link resolver as a service

### DIFF
--- a/Helper/LinkResolver.php
+++ b/Helper/LinkResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Prismic\Bundle\PrismicBundle\Helper;
+
+use Symfony\Component\Routing\RouterInterface;
+
+use Prismic\Api;
+use Prismic\Ref;
+use Prismic\LinkResolver as BaseLinkResolver;
+use Prismic\Fragment\Link\DocumentLink;
+
+abstract class LinkResolver extends BaseLinkResolver
+{
+    private $maybeRef;
+
+    /**
+     * @return string|null
+     */
+    public function getMaybeRef($maybeRef)
+    {
+        $this->maybeRef = $maybeRef;
+    }
+
+    /**
+     * @param string|null $maybeRef
+     */
+    public function setMaybeRef($maybeRef)
+    {
+        $this->maybeRef = $maybeRef;
+    }
+}

--- a/Helper/LocalLinkResolver.php
+++ b/Helper/LocalLinkResolver.php
@@ -6,35 +6,27 @@ use Symfony\Component\Routing\RouterInterface;
 
 use Prismic\Api;
 use Prismic\Ref;
-use Prismic\LinkResolver;
 use Prismic\Fragment\Link\DocumentLink;
 
 class LocalLinkResolver extends LinkResolver
 {
-
-    private $router; 
-    private $api;
-    private $maybeRef;
+    private $router;
 
     /**
      * @param RouterInterface $router
-     * @param Api $api
-     * @param string|null $maybeRef
      */
-    public function __construct(RouterInterface $router, Api $api, $maybeRef = null)
+    public function __construct(RouterInterface $router)
     {
         $this->router = $router;
-        $this->api = $api;
-        $this->maybeRef = $maybeRef;
     }
 
     /**
      * @param DocumentLink $link
      * @return string
      */
-    public function resolve($link) 
+    public function resolve($link)
     {
-        return $this->router->generate('detail', array('id' => $link->getId(), 'slug' => $link->getSlug(), 'ref' => (string) $this->maybeRef));
+        return $this->router->generate('detail', array('id' => $link->getId(), 'slug' => $link->getSlug(), 'ref' => (string) $this->getMaybeRef()));
     }
 
 }

--- a/Helper/PrismicContext.php
+++ b/Helper/PrismicContext.php
@@ -2,8 +2,6 @@
 
 namespace Prismic\Bundle\PrismicBundle\Helper;
 
-use Symfony\Component\Routing\RouterInterface;
-
 use Prismic\api;
 use Prismic\Ref;
 use Prismic\Document;
@@ -12,7 +10,6 @@ use Prismic\Fragment\Link\DocumentLink;
 class PrismicContext
 {
     private $prismic;
-    private $router;
 
     private $accessToken;
     private $api;
@@ -23,12 +20,12 @@ class PrismicContext
 
     /**
      * @param PrismicHelper $prismic
-     * @param RouterInterface $router
+     * @param LinkResolver $linkResolver
      */
-    public function __construct(PrismicHelper $prismic, RouterInterface $router)
+    public function __construct(PrismicHelper $prismic, LinkResolver $linkResolver)
     {
         $this->prismic = $prismic;
-        $this->router = $router;
+        $this->linkResolver = $linkResolver;
     }
 
     /**
@@ -38,7 +35,7 @@ class PrismicContext
     {
         $this->accessToken = $accessToken;
 
-        $this->api = $this->linkResolver = null;
+        $this->api = null;
     }
 
     /**
@@ -48,7 +45,7 @@ class PrismicContext
     {
         $this->ref = $ref;
 
-        $this->maybeRef = $this->linkResolver = null;
+        $this->maybeRef = null;
     }
 
     /**
@@ -112,9 +109,7 @@ class PrismicContext
      */
     public function getLinkResolver()
     {
-        if (!$this->linkResolver) {
-            $this->linkResolver = new LocalLinkResolver($this->router, $this->getApi(), $this->getMaybeRef());
-        }
+        $this->linkResolver->setMaybeRef($this->getMaybeRef());
 
         return $this->linkResolver;
     }
@@ -136,7 +131,7 @@ class PrismicContext
      *
      * @return Document|null
      */
-    public function getDocument($id) 
+    public function getDocument($id)
     {
         $docs = $this->getApi()->forms()->everything->ref($this->getRef())->query(
                 '[[:d = at(document.id, "'.$id.'")]]'

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="prismic.helper.class">Prismic\Bundle\PrismicBundle\Helper\PrismicHelper</parameter>
+        <parameter key="prismic.link_resolver.class">Prismic\Bundle\PrismicBundle\Helper\LocalLinkResolver</parameter>
         <parameter key="prismic.context.class">Prismic\Bundle\PrismicBundle\Helper\PrismicContext</parameter>
     </parameters>
 
@@ -17,9 +18,14 @@
             <argument>%prismic.api.clientSecret%</argument>
         </service>
 
+        <service id="prismic.link_resolver" class="%prismic.link_resolver.class%">
+            <argument type="service" id="router" />
+        </service>
+
         <service id="prismic.context" class="%prismic.context.class%" scope="request">
             <argument type="service" id="prismic.helper" />
             <argument type="service" id="router" />
+            <argument type="service" id="prismic.link_resolver" />
             <call method="setAccessToken"><argument type="expression" on-invalid="null" strict="false">service('request').get('ACCESS_TOKEN')</argument></call>
             <call method="setRef"><argument type="expression" on-invalid="null" strict="false">service('request').query.get('ref')</argument></call>
         </service>


### PR DESCRIPTION
The link resolver instance is now injected as a service for easier overwriting from other bundles through for example compiler passes.
