### PR TITLE
Using request_stack to get current request and removed request scope.

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -17,11 +17,11 @@
             <argument>%prismic.api.clientSecret%</argument>
         </service>
 
-        <service id="prismic.context" class="%prismic.context.class%" scope="request">
+        <service id="prismic.context" class="%prismic.context.class%">
             <argument type="service" id="prismic.helper" />
             <argument type="service" id="router" />
-            <call method="setAccessToken"><argument type="expression" on-invalid="null" strict="false">service('request').get('ACCESS_TOKEN')</argument></call>
-            <call method="setRef"><argument type="expression" on-invalid="null" strict="false">service('request').query.get('ref')</argument></call>
+            <call method="setAccessToken"><argument type="expression" on-invalid="null" strict="false">service('request_stack').getCurrentRequest().get('ACCESS_TOKEN')</argument></call>
+            <call method="setRef"><argument type="expression" on-invalid="null" strict="false">service('request_stack').getCurrentRequest().query.get('ref')</argument></call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Since SF 2.4 (the minimum of this bundle in composer.json) a best practice is to use the _request_stack_ instead of the _request_ service. This also helps with some DI/scope related things because the request scope can be removed from the service.
