### PR TITLE
Remove unnecessary call to getMasterRef()

### DIFF
--- a/EventListener/ContextListener.php
+++ b/EventListener/ContextListener.php
@@ -37,14 +37,14 @@ class ContextListener
         $previewCookie = str_replace('.', '_', Prismic\PREVIEW_COOKIE);
         $experimentsCookie = str_replace('.', '_', Prismic\EXPERIMENTS_COOKIE);
 
-        $newRef = $this->context->getMasterRef();
         if ($request->cookies->has($previewCookie)) {
             $newRef = $request->cookies->get($previewCookie);
         } else if ($request->cookies->has($experimentsCookie)) {
             $cookie = $request->cookies->get($experimentsCookie);
             $newRef = $this->context->getApi()->getExperiments()->refFromCookie($cookie);
         }
-        $this->context->setRef($newRef);
+        
+        isset($newRef) and $this->context->setRef($newRef);
     }
 
 }


### PR DESCRIPTION
The call to getMasterRef() in the context listener is unnecessary and slows every request in a Symfony app down, regardless of usage of Prismic on a page. `PrismicContext::getRef()` does `getMasterRef` internally when no ref was set before, so it's only called when needed.

Edit: Added info about the location of the call to getMasterRef()